### PR TITLE
Back end implementing for my page

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,6 +1,6 @@
 .MyPageWrapper {
   width: 100%;
-  height: 100vh;
+  height: 100%;
   display: flex;
   justify-content: center;
   background-color: #eeeeee;
@@ -8,7 +8,9 @@
     width: 1020px;
     display: flex;
     justify-content: center;
-    margin: 40px auto 0;
+    margin: 40px 0;
+    overflow: hidden;
+    overflow-y: scroll;
     &__LeftSide {
       width: 280px;
       background-color: #fff;
@@ -79,6 +81,11 @@
       height: 90vh;
       background-color: #fff;
       margin-left: 40px;
+      h2 {
+        padding-top: 170px;
+        text-align: center;
+        font-size: 30px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,6 +1,5 @@
 .MyPageWrapper {
   width: 100%;
-  height: 100%;
   display: flex;
   justify-content: center;
   background-color: #eeeeee;
@@ -9,8 +8,6 @@
     display: flex;
     justify-content: center;
     margin: 40px 0;
-    overflow: hidden;
-    overflow-y: scroll;
     &__LeftSide {
       width: 280px;
       background-color: #fff;
@@ -77,9 +74,8 @@
       }
     } 
     &__RightSide {
+      display: inline-block;
       width: 700px;
-      height: 90vh;
-      background-color: #fff;
       margin-left: 40px;
       h2 {
         padding-top: 170px;
@@ -89,4 +85,23 @@
     }
   }
 }
+
+.LogOutBtn {
+  height: 150px;
+  text-align: center;
+  padding: 60px 0;
+  background-color: #fff;
+  #myPageLogOutBtn {
+    width: 300px;
+    text-decoration: none;
+    font-size: 14px;
+    padding: 10px 70px;
+    margin-top: 80px;
+    background-color: #ea352d;
+    color: #fff;
+    border-radius: 4px;
+    border: none;
+  }
+}
+
   

--- a/app/controllers/product_addresses_controller.rb
+++ b/app/controllers/product_addresses_controller.rb
@@ -6,8 +6,9 @@ class ProductAddressesController < ApplicationController
 
   def create
     @product_address = ProductAddress.new(product_address_params)
+
     if @product_address.save
-      redirect_to product_addresses_path
+      redirect_to users_path
     else
       render :new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,4 @@
 class UsersController < ApplicationController
+  def logout
+  end
 end

--- a/app/views/product_addresses/edit.html.haml
+++ b/app/views/product_addresses/edit.html.haml
@@ -1,54 +1,59 @@
-.subWrapper
-  .ProductAdress
-    .ProductAdress__title
-      商品送付先住所情報登録
-    .ProductAdress__formBox
-      = form_with model: @product_address, local: true do |f|
-        .ProductAdress__errorMessages
-          = render 'layouts/error_messages', model: f.object
-        .field
-          = f.label :お名前（全角）, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          .field__nameInput
-            = f.text_field :first_name, placeholder: "例)山田", autofocus: true, autocomplete: ""
-            = f.text_field :last_name, placeholder: "例)太郎", autofocus: true, autocomplete: ""
-        .field
-          = f.label :お名前カナ（全角）, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          .field__nameInput
-            = f.text_field :first_name_kana, placeholder: "例)ヤマダ", autofocus: true, autocomplete: ""
-            = f.text_field :last_name_kana, placeholder: "例)ハナコ", autofocus: true, autocomplete: ""
-        .field
-          = f.label :郵便番号, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          = f.text_field :postal_code, placeholder: "例)1234567", autofocus: true, autocomplete: ""
-        .field
-          = f.label :都道府県, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          = f.collection_select :prefecture_code, JpPrefecture::Prefecture.all, :code, :name, selected: 27
-        .field
-          = f.label :市町村区, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          = f.text_field :address_city , placeholder: "例)大阪市北区", autofocus: true, autocomplete: ""
-        .field
-          = f.label :番地, class: "label_head"
-          = f.label :必須, class: "label_required"
-          %br/
-          = f.text_field :address_street, placeholder: "例)1-2-345", autofocus: true, autocomplete: ""
-        .field
-          = f.label :マンション・ビル名、部屋番号, class: "label_head"
-          = f.label :任意, class: "label_any"
-          %br/
-          = f.text_field :building_name, placeholder: "例)メゾンFULIMA A101", autofocus: true, autocomplete: ""
-        .field
-          = f.label :お届け先電話番号, class: "label_head"
-          = f.label :任意, class: "label_any"
-          %br/
-          = f.telephone_field :phone_number, placeholder: "例)09012345678", autofocus: true, autocomplete: ""
-        .actions
-          = f.submit "登録する"
+.MyPageWrapper
+  .MyPageContents
+    .MyPageContents__LeftSide
+      = render 'users/mypage_leftside'
+    .MyPageContents__RightSide
+      .subWrapper
+        .ProductAdress
+          .ProductAdress__title
+            商品送付先住所情報登録
+          .ProductAdress__formBox
+            = form_with model: @product_address, local: true do |f|
+              .ProductAdress__errorMessages
+                = render 'layouts/error_messages', model: f.object
+              .field
+                = f.label :お名前（全角）, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                .field__nameInput
+                  = f.text_field :first_name, placeholder: "例)山田", autofocus: true, autocomplete: ""
+                  = f.text_field :last_name, placeholder: "例)太郎", autofocus: true, autocomplete: ""
+              .field
+                = f.label :お名前カナ（全角）, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                .field__nameInput
+                  = f.text_field :first_name_kana, placeholder: "例)ヤマダ", autofocus: true, autocomplete: ""
+                  = f.text_field :last_name_kana, placeholder: "例)ハナコ", autofocus: true, autocomplete: ""
+              .field
+                = f.label :郵便番号, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                = f.text_field :postal_code, placeholder: "例)1234567", autofocus: true, autocomplete: ""
+              .field
+                = f.label :都道府県, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                = f.collection_select :prefecture_code, JpPrefecture::Prefecture.all, :code, :name, selected: 27
+              .field
+                = f.label :市町村区, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                = f.text_field :address_city , placeholder: "例)大阪市北区", autofocus: true, autocomplete: ""
+              .field
+                = f.label :番地, class: "label_head"
+                = f.label :必須, class: "label_required"
+                %br/
+                = f.text_field :address_street, placeholder: "例)1-2-345", autofocus: true, autocomplete: ""
+              .field
+                = f.label :マンション・ビル名、部屋番号, class: "label_head"
+                = f.label :任意, class: "label_any"
+                %br/
+                = f.text_field :building_name, placeholder: "例)メゾンFULIMA A101", autofocus: true, autocomplete: ""
+              .field
+                = f.label :お届け先電話番号, class: "label_head"
+                = f.label :任意, class: "label_any"
+                %br/
+                = f.telephone_field :phone_number, placeholder: "例)09012345678", autofocus: true, autocomplete: ""
+              .actions
+                = f.submit "登録する"

--- a/app/views/users/_mypage_leftside.html.haml
+++ b/app/views/users/_mypage_leftside.html.haml
@@ -1,0 +1,32 @@
+%nav.functions
+  %ul
+    %li.function-mypage
+      = link_to 'マイページ', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to '出品した商品 - 出品中', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to '出品した商品 - 売却済み', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to '購入した商品 - 過去の取引', "/"
+      %i.fas.fa-chevron-right
+  %h3.settings
+    設定
+  %ul
+    %li.function
+      = link_to 'プロフィール', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to '商品送付先住所変更', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to 'メール/パスワード', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to 'クレジットカード登録', "/"
+      %i.fas.fa-chevron-right
+    %li.function
+      = link_to 'ログアウト', "/"
+      %i.fas.fa-chevron-right

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,37 +1,7 @@
 .MyPageWrapper
   .MyPageContents
     .MyPageContents__LeftSide
-      %nav.functions
-        %ul
-          %li.function-mypage
-            = link_to 'マイページ', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to '出品した商品 - 出品中', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to '出品した商品 - 売却済み', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to '購入した商品 - 過去の取引', "/"
-            %i.fas.fa-chevron-right
-        %h3.settings
-          設定
-        %ul
-          %li.function
-            = link_to 'プロフィール', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to '商品送付先住所変更', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to 'メール/パスワード', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to 'クレジットカード登録', "/"
-            %i.fas.fa-chevron-right
-          %li.function
-            = link_to 'ログアウト', "/"
-            %i.fas.fa-chevron-right
+      = render 'users/mypage_leftside'
     .MyPageContents__RightSide
-      hello
+      %h2
+        FULIMAようこそ

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,0 +1,8 @@
+.MyPageWrapper
+  .MyPageContents
+    .MyPageContents__LeftSide
+      = render 'users/mypage_leftside'
+    .MyPageContents__RightSide
+      .LogOutBtn
+        = link_to destroy_user_session_path, method: :delete, id: "myPageLogOutBtn" do
+          ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   root 'items#index'
   
-  resources :users, only: :index
+  resources :users, only: :index do
+    get 'logout'
+  end
   resources :profiles
   resources :product_addresses, only: [ :new, :create, :edit, :update ]
   resources :credits

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_08_06_111607) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -96,5 +96,4 @@ ActiveRecord::Schema.define(version: 0) do
   add_foreign_key "item_images", "items"
   add_foreign_key "product_addresses", "users"
   add_foreign_key "profiles", "users"
-  
 end


### PR DESCRIPTION
#WHAT
- マイページ機能の実装
  - 商品送先住所情報ページの遷移先viewを作成
  - ログアウトの遷移先viewを作成
  - プリフィール、メールの遷移先のviewは他メンバーのマージ後に行う。
  - ボタンのリンク先は未実装


#WHY
- 他メンバーの変更内容を吸収しないと次の作業が行えないため。
  - ログイン機能がないとリンクが作成できない。
  - メールのviewが他メンバーによって変更中で手を加えられない。