### PR TITLE
Error handlings implementing

### DIFF
--- a/app/assets/stylesheets/_item_new.scss
+++ b/app/assets/stylesheets/_item_new.scss
@@ -20,7 +20,7 @@
       padding-bottom: 60px;
       padding-top: 10px;
       &__errorMessage {
-        padding: 5px 0 5px 230px;
+        padding: 30px 0 5px 250px;
       }
       .postContent {
         padding: 40px 40px;

--- a/app/assets/stylesheets/_item_new.scss
+++ b/app/assets/stylesheets/_item_new.scss
@@ -19,6 +19,9 @@
       min-height: 100vh;
       padding-bottom: 60px;
       padding-top: 10px;
+      &__errorMessage {
+        padding: 5px 0 5px 230px;
+      }
       .postContent {
         padding: 40px 40px;
       }

--- a/app/assets/stylesheets/product_addresses.scss
+++ b/app/assets/stylesheets/product_addresses.scss
@@ -53,7 +53,7 @@
   height: 50px;
   width: 343px;
   margin: 8px 0 0 ;
-  color: gray;
+  color: #333;
 }
 input[type="submit"] {
   height: 50px;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -98,13 +98,29 @@
 
 // マイページLP
 .LogInMassage {
-  height: 150px;
+  height: 610px;
   text-align: center;
   background-color: #fff;
-  .welcom_message {
-    font-size: 25px;
-    font-weight: 600;
+  &__logo {
+    font-size: 100px;
     line-height: 150px;
     color: #333;
+  }
+  &__border {
+    width: 550px;
+    border-top: 2px solid lightgray;
+    margin: 0 auto;
+  }
+  .welcom_message {
+    height: 200px;
+    font-size: 25px;
+    font-weight: 600;
+    line-height: 300px;
+    color: #333;
+  }
+  .welcom_sentence {
+    font-size: 18px;
+    padding-top: 30px;
+    line-height: 40px;
   }
 }  

--- a/app/controllers/product_addresses_controller.rb
+++ b/app/controllers/product_addresses_controller.rb
@@ -25,7 +25,7 @@ class ProductAddressesController < ApplicationController
   def update
     @product_address = ProductAddress.find(params[:id])
     if @product_address.update(product_address_params)
-      redirect_to product_addresses_path
+      redirect_to users_path
     else
       render :edit
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_one :product_address, dependent: :destroy
   has_one :credit, dependent: :destroy
 
-  validates :nickname,
+  validates :nickname, :email, :passoword,
     presence: true,
     length: { maximum: 10 }
 end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,6 +8,7 @@
           %h2 ログイン
         .Account__master__entry__form
           = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+            = render "devise/shared/error_messages", resource: resource
             .Formfiled
               .Formfiled_lavel
                 .field_one

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -74,7 +74,7 @@
           = f.collection_select :delivery_charge_id, DeliveryCharge.all, :name, :name, {include_blank: "選択してください"}, {class: "inputInformation"}
           .selectShow   
             .selectNameIntro__name
-              配送元に地域
+              配送元の地域
             .selectTitle__required
               必須
           = f.collection_select :delivery_origin_id, DeliveryOrigin.all, :name, :name, {include_blank: "選択してください"}, {class: "inputInformation"}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -5,6 +5,8 @@
   .postForm__main
     = form_with model: @item, id: "item-dropzone", local: true do |f|
       .postContents
+        .postContents__errorMessage
+          = render 'layouts/error_messages', model: f.object
         .postContent
           .selectTitle
             .selectTitle__info

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -6,7 +6,7 @@
     = form_with model: @item, id: "item-dropzone", local: true do |f|
       .postContents
         .postContents__errorMessage
-          = render 'layouts/error_messages', model: f.object
+          = render 'layouts/flash_notification'
         .postContent
           .selectTitle
             .selectTitle__info

--- a/app/views/layouts/_flash_notification.html.haml
+++ b/app/views/layouts/_flash_notification.html.haml
@@ -1,0 +1,3 @@
+.Notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,7 +4,15 @@
       = render 'users/mypage_leftside'
     .MyPageContents__RightSide
       .LogInMassage
+        .LogInMassage__logo
+          = image_tag src="material/logo/logo.png", size: "150x50", class: "logo"
+        .LogInMassage__border
         .welcom_message
           ようこそ
           = current_user.nickname
           さん
+        .welcom_sentence
+          FULIMAはあなたのフリマ生活の最良のパートナーです
+          %br/
+          FULIMAで最適最高のフリマ生活を楽しみましょう
+        

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,8 +23,8 @@ ja:
       credit:
       delivery_charge:
       delivery_date:
-      item: "商品画像"
-      item_image: "商品画像"
+      item:
+      item_image: "出品画像"
     attributes:
       user:
         nickname: "ニックネーム"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,15 @@ ja:
     models:
       user:
       product_address:
+      profile:
+      item:
+      category: "カテゴリー"
+      condition:
+      credit:
+      delivery_charge:
+      delivery_date:
+      item: "商品画像"
+      item_image: "商品画像"
     attributes:
       user:
         nickname: "ニックネーム"
@@ -39,6 +48,21 @@ ja:
         address_street: "番地"
         building_name: "マンション名・ビル名"
         phone_number: "お届け先電話番号"
+      item:
+        name: "商品名"
+        introduction: "商品の説明"
+        brand: "ブランド"
+        condition_id: "商品の状態"
+        delivery_charge_id: "配送料の負担"
+        delivery_origin_id: "配送元の地域"
+        delivery_date_id: "配送までの日数"
+        category_id: "１つ目のカテゴリー"
+        category: "２つ目、３つ目カテゴリー"
+        price: "販売価格"
+        seller_id: "出品中"
+        buyer_id: "購入済み"
+      item_image:
+        image: "商品画像"
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"


### PR DESCRIPTION
#WHAT
- エラーハンドリングを実装した。
  - item new にフラッシュメッセージで送信失敗時のエラーを表示するようにした。
- マイページのログイン後のページにロゴと歓迎文を挿入した。

#WHY
- 要件定義にエラーハンドリグがあり実装が必要だから。