### PR TITLE
Session#new and Registration#new [MarkUp][BackEnd]:  Error handlings implementing2

### DIFF
--- a/app/assets/stylesheets/_devise.scss
+++ b/app/assets/stylesheets/_devise.scss
@@ -66,6 +66,9 @@ label {
         &__form {
           display: flex;
           justify-content: center;
+          .errorMessage {
+            padding-left: 55px;
+          }
           .Formfiled {
             margin: 32px;
               .field_one {

--- a/app/assets/stylesheets/_devise.scss
+++ b/app/assets/stylesheets/_devise.scss
@@ -67,6 +67,8 @@ label {
           display: flex;
           justify-content: center;
           .errorMessage {
+            color: red;
+            font-size: 14px;
             padding-left: 55px;
           }
           .Formfiled {

--- a/app/assets/stylesheets/_item_new.scss
+++ b/app/assets/stylesheets/_item_new.scss
@@ -20,6 +20,8 @@
       padding-bottom: 60px;
       padding-top: 10px;
       &__errorMessage {
+        color: red;
+        font-size: 14px;
         padding: 30px 0 5px 250px;
       }
       .postContent {

--- a/app/assets/stylesheets/product_addresses.scss
+++ b/app/assets/stylesheets/product_addresses.scss
@@ -108,6 +108,7 @@ input[type="submit"]:active {
     &__master{
       background-color: #fff;
       padding: 0 135px;
+      margin-bottom: 50px;
     }
     &__title {
       width: 100%;

--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -76,7 +76,7 @@
 .subWrapper {
   display: flex;
   justify-content: center;
-  background-color:#fff;
+  background-color:#eeeeee;
   .Profile {
     width: 700px;
     display: flex;
@@ -86,6 +86,7 @@
     &__master{
       background-color: #fff;
       padding: 0 135px;
+      margin-bottom: 50px;
     }
     &__master_edit{
       width: 100%;

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -10,7 +10,7 @@
           = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
             = render "devise/shared/error_messages", resource: resource
             .Formfiled
-              .Formfiled_lavel
+              .Formfiled_label
                 .field_one
                   = f.label :メールアドレス
                 .field_second

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,7 +8,8 @@
           %h2 ログイン
         .Account__master__entry__form
           = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-            = render "devise/shared/error_messages", resource: resource
+            .errorMessage
+              = render 'layouts/flash_notification'
             .Formfiled
               .Formfiled_lavel
                 .field_one

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,13 +11,13 @@
             .errorMessage
               = flash[:alert]
             .Formfiled
-              .Formfiled_lavel
+              .Formfiled_label
                 .field_one
                   = f.label :メールアドレス
                 .field_second
                   = f.email_field :email, autofocus: true, autocomplete: "email", class:"field", placeholder:"xxx@furima.com"
             .Formfiled
-              .Formfiled_lavel
+              .Formfiled_label
                 .field_one
                   = f.label :パスワード
                 .field_second

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -9,7 +9,7 @@
         .Account__master__entry__form
           = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
             .errorMessage
-              = render 'layouts/flash_notification'
+              = flash[:alert]
             .Formfiled
               .Formfiled_lavel
                 .field_one

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -6,7 +6,7 @@
     = form_with model: @item, id: "item-dropzone", local: true do |f|
       .postContents
         .postContents__errorMessage
-          = render 'layouts/flash_notification'
+          = flash[:alert]
         .postContent
           .selectTitle
             .selectTitle__info

--- a/app/views/product_addresses/new.html.haml
+++ b/app/views/product_addresses/new.html.haml
@@ -6,6 +6,7 @@
       .ProductAdress__entry
         .ProductAdress__title
           商品送付先住所情報登録
+        .ProductAdress__border
         .ProductAdress__formBox
           = form_with model: @product_address, local: true do |f|
             .ProductAdress__errorMessages

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -6,6 +6,7 @@
       .Profile__entry
         .Profile__title
           会員情報入力
+        .Profile__border
         .Profile__formBox
           = form_with model:@profile,local:true do |f|
             .Profile__errorMessages

--- a/app/views/users/_mypage_leftside.html.haml
+++ b/app/views/users/_mypage_leftside.html.haml
@@ -26,7 +26,7 @@
     %li
       = link_to edit_profile_path(current_user.id) do
         .function
-          プロフィール 登録・変更
+          会員情報 登録・変更
           %i.fas.fa-chevron-right
     %li
       = link_to edit_product_address_path(current_user.id) do

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,7 +14,7 @@ ja:
       phone_number: "お届け先電話番号"
   activerecord:
     models:
-      user:
+      user: "ユーザー情報"
       product_address:
       profile:
       item:


### PR DESCRIPTION
# WHAT
- 【マークアップ】ユーザー新規登録/ログインページ 
  - ユーザー登録はnickname,email,passwordで行える。
  - ユーザー登録後、マイページから会員情報と送付先住所情報を登録する仕様で実装を行った。これによって、DBに存在するデータの入力を網羅している。
  - 出品は送付先住所情報を登録していないとできない仕様で開発中。
- ３人で作業を分担し、各ブランチをつなげて機能を完成させた。以下作業分担(プルリクエスト番号)。
  - #11 送付先住所情報の登録画面のマークアップ
  - #16 ユーザー新規登録、ログイン画面のマークアップ
  - #18 プロフィール入力画面のマークアップ
  - #26 ユーザー新規登録・会員情報登録・送付先住所情報登録のSCSSを見本サイトFURIMAと同じものに統一する。
  - #46 ログイン画面に入力エラー時のメッセージを表示する機能を実装。

# WHY
- 本アプリケーションの主幹機能のため。
  - ユーザー登録なしでは商品出品・購入ができない機能になっているため。