### PR TITLE
Items#index implementing: Item views debug

### DIFF
--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -46,6 +46,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      position: relative;
       margin-top: 5px;
     }
     .itemSubImage {

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -222,6 +222,7 @@
       .mainNew {
         display: flex;
         &__contents {
+          position: relative;
           background-color: #fff;
           height: 280px;
           cursor: pointer;
@@ -378,3 +379,21 @@
   }
 }
 
+// 売却済みのリボン
+.sold_triangle {
+  position: absolute;
+  right: 0;
+  width: 0;
+  height: 0;
+  opacity: 0.9;
+  border-style: solid;
+  border-width: 0 100px 100px 0;
+  border-color: transparent red transparent transparent;
+  .sold_word {
+    color: #fff;
+    font-size: 18px;
+    font-weight: 600;
+    padding: 10px 60px 0px 45px;
+    transform: rotate(45deg);
+  }
+}

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -218,31 +218,41 @@
       margin: 0 auto;
       display: flex;
       overflow-x: auto;
-      white-space: nowrap;
+      // white-space: nowrap;
       .mainNew {
         display: flex;
         &__contents {
           background-color: #fff;
           height: 280px;
           cursor: pointer;
-          margin-left: 15px;
+          margin: 0 0 10px 15px;
           border: 1px solid white;
+          .item-content-pic {
+            padding: 5px;
+          }
           .mainNew-info {
             padding: 5px;
             padding-left: 10px;
             .mainNew-name {
-              overflow: visible;
+              padding: 5px;
+              height: 40px;
               width: 200px;
-              font-size: 19px;
+              font-size: 14px;
+              word-break: keep-all;
             }
             .mainNew-price {
-              margin-top: 40px;
+              padding-left: 7px;
+              margin-top: 30px;
               font-size: 15px;
             }
             .mainNew-tax {
+              padding-left: 7px;
               font-size: 12px;
             }
           }
+        }
+        &__contents:hover {
+          border: 1px solid blue;
         }
       }
     }

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -218,7 +218,6 @@
       margin: 0 auto;
       display: flex;
       overflow-x: auto;
-      // white-space: nowrap;
       .mainNew {
         display: flex;
         &__contents {

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -100,7 +100,7 @@
               .mainNew-name
                 = item.name
               .mainNew-price
-                = item.price
+                = item.price.to_s(:delimited)
                 円
               .mainNew-tax
                 (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -89,6 +89,10 @@
       - @items.each do |item|
         .mainNew
           .mainNew__contents
+            - if !item.buyer_id.nil?
+              .sold_triangle
+                .sold_word
+                  SOLD
             .item-content-pic
               =link_to item_path(item), method: :get do
                 =image_tag item.item_images[0].image.url, class: "item-photos", size: "220x140"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -18,7 +18,7 @@
           = image_tag i.image.url,class: "subImage", size: "110x80"
     .itemShow__main__price
       ¥
-      = @item.price
+      = @item.price.to_s(:delimited)
     .itemShow__main__tax
       (税込)
       = @item.delivery_charge_id

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,6 +11,10 @@
     .itemShow__main__name
       = @item.name
     .itemShow__main__image
+      - if !@item.buyer_id.nil?
+        .sold_triangle
+          .sold_word
+            SOLD
       - if @item.item_images[0]
         = image_tag @item.item_images[0].image.url,size: "560x346",class: "mainImage"
       .itemSubImage


### PR DESCRIPTION
# WHAT
- 【サーバサイド】商品一覧表示
  - トップページに新規に出品された商品がピックアップカテゴリーとして、５枚表示されるように実装した。スクロールすれば、過去のものも閲覧は可能。
  - 表示された商品には、「商品画像/商品名/価格」が表示される。
  - 売り切れた商品には、写真の右上に「SOLD」が表示されるようになっている。
  - ログイン状態にかかわらず、トップページは閲覧が可能のため、商品一覧も閲覧ができる仕様となっている。

# WHY
- 一覧表示は依頼側の必須要件であるため。
- トップページに目を引く一覧を表示させることで、閲覧時間・使用時間を伸ばし、ユーザーの利用につなげる狙いがあるため。
- 一覧を作ることにより、購買目的のなかったビジターにも興味を持たせ、利用につなげる狙いがあるため。

# 補足
- 他メンバーの作業内容を吸収しないと進められない作業があったことや修正点の後発見により複数のブランチを切って作業を行った。
- ２人で作業を分担し、各ブランチをつなげて機能を完成させた。以下作業分担(プルリクエスト番号)。
  - #9 #13 #27 #39 インデックスのマークアップとサーバー実装
  - #48 売り切れの商品に「SOLD」の表示をつける。マークアップのデバッグ