### PR TITLE
[WHIP]created_item_show_flont

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,4 @@
 .itemShow
-  .postContents__errorMessage
-    = render 'layouts/flash_notification'
   .itemShow__main
     -if user_signed_in? && @item.seller_id == current_user.id
       .itemBox


### PR DESCRIPTION
# What

[フロントサイド]商品詳細表示
商品詳細表示のフロントサイドの実装

# WHY

本アプリケーションの主幹機能のため。

補足  
他メンバーの作業内容を吸収しないと進められない作業があったことや修正点の後発見により複数のブランチを切って作業を行った。  
マージ履歴　＃30 　＃38