### PR TITLE
ER-Photo3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fleamarket_sample_80b
 
 
-![ER図](https://gyazo.com/cd2479027cbbdaee8383aed3e81f01f2)
+![ER図]("https://gyazo.com/2c670df569600a999b35a57f398fb19b")
 
 ## usersテーブル
 


### PR DESCRIPTION
# WHAT
- ER図リンク修正
  - 記載に誤りがありました。

# WHY
- 記載方法に誤りがあったため
  -  ””の抜けがありました。